### PR TITLE
proofead: src/htop/README.adoc

### DIFF
--- a/src/htop/README.adoc
+++ b/src/htop/README.adoc
@@ -9,10 +9,10 @@ To load htop:
 htop
 ----
 
-You can quit at any time by pressing the F10 or Q keys.
+You can quit at any time by pressing `F10` or `q`.
 
 The memory utilization graph displays used memory, buffered memory, and cached memory. The numbers displayed at the end of this graph reflect the total amount of memory available and the total amount of memory on the system as reported by the kernel.
 
-The default configuration of htop presents all application threads as independent processes. You can disable this by selecting the setup option with F2, then "Display Options", and then toggling the "Hide userland threads" option.
+The default configuration of htop presents all application threads as independent processes. You can disable this by pressing `F2` to open Setup, then selecting "Display Options", and then toggling the "Hide userland threads" option.
 
-Press F5 to toggle the tree view, which displays the processes in a hierarchy, showing which processes were spawned by which other processes. This is helpful in identifying what processes are what.
+Press `F5` to toggle the tree view, which displays the processes in a hierarchy, showing which processes were spawned by which other processes. This is helpful for identifying process relationships.


### PR DESCRIPTION
- Changed "pressing the F10 or Q keys" to "pressing `F10` or `q`" — htop uses lowercase q to quit.
- Added backticks around key references (`F10`, `q`, `F2`, `F5`) for valid AsciiDoc inline code formatting.
- Rephrased the setup navigation instruction for clarity.
- Changed the final sentence from "identifying what processes are what" to "identifying process relationships" for improved readability.