### PR TITLE
proof: gpg

### DIFF
--- a/src/gpg/README.adoc
+++ b/src/gpg/README.adoc
@@ -6,11 +6,11 @@ https://www.gnupg.org/[GPG] is a free, open source implementation of the OpenPGP
 
 == How GPG works
 
-GPG implements key-based asymmetric cryptography. You using the `gpg` utility to create two mathematically related keys:
+GPG implements key-based asymmetric cryptography. You use the `gpg` utility to create two mathematically related keys:
 
 * A *public key*, which you share openly, and which is used by others to encrypt messages that they send to you, or to verify your signatures.
 
-* A *private key*, which you keep secret, and which you use to decrypt messages that are sent to you, or which you use to create digital signatures uses for signing your own messages.
+* A *private key*, which you keep secret, and which you use to decrypt messages that are sent to you, or to create digital signatures for your own messages.
 
 Thus, when someone wants to send you a secure message – whether by email or any other insecure channel – they use your public key to encrypt it. Only you can decrypt it with your private key.
 
@@ -38,8 +38,8 @@ GPG can be used to encrypt, decrypt, sign, and verify any arbitrary data. Common
 
 For example, when adding packages from third-party repositories in Linux, GPG keys tend to be used to verify the authenticity of the downloaded packages. It works like this:
 
-1. Third-party package providers sign their packages, adding a signature in the package metadata using their private GPG key.
-2. The third-party repository publishes its public GPG key at a publicly-accessible web address.
+1. Third-party package providers sign their packages, adding a signature to the package metadata using their private GPG key.
+2. The third-party repository publishes its public GPG key at a publicly accessible web address.
 3. You download and add the public key to your system's trusted keyring.
 4. When you install packages from the third-party repository, your package manager verifies the authenticity of the downloaded packages by verifying the packages' signatures with the public key. Only valid packages are installed.
 
@@ -92,7 +92,7 @@ If you don't already have a GPG key, create one with the following command.
 $ gpg --full-generate-key
 ----
 
-At the prompts, choose RSA, 4096 bits, and set an expiration date. For your uid, use the same email address you use to create Git commits that will be pushed to GitHub/GitLab. If you use a private email aliases provided by GitHub, use that.
+At the prompts, choose RSA, 4096 bits, and set an expiration date. For your uid, use the same email address you use to create Git commits that will be pushed to GitHub/GitLab. If you use a private email alias provided by GitHub, use that.
 
 Optionally, you can set a passphrase to protect your private key. If you set a passphrase, you'll need to enter it each time you use the key (though the GPG agent can cache it for a while). You may also need to add the following line to your `~/.bashrc` or `~/.zshrc` file. This tells GPG to use the current terminal for passphrase prompts.
 
@@ -177,7 +177,7 @@ $ gpg --armor --export YOUR_EMAIL > public.key
 
 Copy the files to somewhere on the Windows filesystem.
 
-Open Kleopatra, an OpenPGP certificate and key management utility that is installed with GPG4Win. Go to *File -> Import Certificates*, and import both the `public.key` and `private.key` files you exported from WSL. The key should now be listed in Kleopatra, under *Certificates*.
+Open Kleopatra, an OpenPGP certificate and key management utility that is installed with GPG4Win. Go to *File -> Import Certificates*, and import both the `public.key` and `private.key` files you exported from WSL. The keys should now be listed in Kleopatra, under *Certificates*.
 
 Alternatively, you can import the keys via the command line:
 
@@ -203,10 +203,10 @@ Verify the import:
 
 [IMPORTANT]
 ======
-Delete the original `public.key` and `private.key` files after importing them to GPG.
+Delete the original `public.key` and `private.key` files after importing them into GPG.
 ======
 
-To test the configuration, make a commit from a Windows GUI Git client, and you should be prompted for your GPG key's passphrase via a Windows GUI dialog. Also test via WSL, using either of the below commands; because this is expected to use the native `gpg` binary installed in WSL, you will see the default terminal prompt for your passphrase.
+To test the configuration, make a commit from a Windows GUI Git client, and you should be prompted for your GPG key's passphrase via a Windows GUI dialog. Also test via WSL, using either of the below commands; because this is expected to use the native `gpg` binary installed in WSL, and you will see the default terminal prompt for your passphrase.
 
 ----
 # Sign an arbitrary piece of text.
@@ -230,7 +230,7 @@ But of course you're now using the Windows agent, so you need to issue the follo
 taskkill /f /im gpg-agent.exe
 ----
 
-On the next GPG command, it will take a few seconds for the agent to startup, and then you will be prompted for your passphrase again.
+On the next GPG command, it will take a few seconds for the agent to start up, and then you will be prompted for your passphrase again.
 ======
 
 == Passphrase caching
@@ -247,7 +247,7 @@ default-cache-ttl 3600
 max-cache-ttl 7200
 ----
 
-These optional settings are required only if you're using gpg-agent for SSH authentication:
+The following optional settings apply only if you're using gpg-agent for SSH authentication:
 
 ----
 default-cache-ttl-ssh 3600


### PR DESCRIPTION
Changes to `src/gpg/README.adoc`:

- Fixed subject-verb agreement: "You using the `gpg` utility..." → "You use the `gpg` utility..."
- Streamlined and corrected the description of private key usage: removed redundant "which you use" and fixed "signatures uses for signing" → "signatures for your own messages"
- Changed "adding a signature in the package metadata" → "adding a signature to the package metadata"
- Removed unnecessary hyphen: "publicly-accessible" → "publicly accessible"
- Fixed singular/plural agreement: "a private email aliases" → "a private email alias"
- Fixed pronoun agreement: "The key should now be listed" → "The keys should now be listed" (referring to both public and private keys)
- Changed "importing them to GPG" → "importing them into GPG"
- Fixed comma splice: added "and" before "you will see the default terminal prompt"
- Fixed verb phrase: "agent to startup" → "agent to start up"
- Removed contradictory wording: "These optional settings are required" → "The following optional settings apply"