### PR TITLE
proof: aws/compute

### DIFF
--- a/src/aws/compute/ec2.adoc
+++ b/src/aws/compute/ec2.adoc
@@ -63,7 +63,7 @@ systemctl start httpd
 systemctl enable httpd
 ----
 
-User Data is limited to 16KB in size, so its only good for simple scripts. For Windows instances, you can run Batch and Powershell scripts as well as Bash ones.
+User Data is limited to 16KB in size, so it's only good for simple scripts. For Windows instances, you can run Batch and Powershell scripts as well as Bash ones.
 
 == EC2 Metadata
 

--- a/src/aws/compute/ecs.adoc
+++ b/src/aws/compute/ecs.adoc
@@ -2,11 +2,11 @@
 
 AWS supports the use of Docker containers for deployment of applications.
 
-Docker is an ideal choice for *cloud-native applications* — that is, things lke microservices that are designed from the ground-up to be deployed into distributed, virtualized environments, and which have a high degree of decoupling from the underlying infrastructure on which they run, and even from things like network messaging (for communication between components).
+Docker is an ideal choice for *cloud-native applications* — that is, things like microservices that are designed from the ground-up to be deployed into distributed, virtualized environments, and which have a high degree of decoupling from the underlying infrastructure on which they run, and even from things like network messaging (for communication between components).
 
 The *Elastic Container Service (ECS)* is the service we use to launch Docker containers in AWS. Only Docker containers are supported by AWS at this time, but both Linux and Windows Docker containers are supported.
 
-With ECS, we can choose to deploy an *ECS cluster*, which may span multiple availability zones. An ECS cluster is a logic grouping of tasks or services.
+With ECS, we can choose to deploy an *ECS cluster*, which may span multiple availability zones. An ECS cluster is a logical grouping of tasks or services.
 
 image::../_/ecs-cluster-across-azs.drawio.svg[]
 
@@ -39,7 +39,7 @@ An *EC2 container instance* is an EC2 instance that hosts an ECS container.
 
 We use an *EC2 launch type* to launch EC2 instances into our account, and those instances must have the *EC2 Container Agent* running, so we can join them into an ECS cluster. Those EC2 instances become the hosts on which our containers are run.
 
-Unlike ECS tasks and services (which are a bit more "serverless"), we manage ourselves the EC2 instances that are used to host our ECS container instances. However, you get all the normal features of EC2, including auto-scaling. You have more work to do to optimize your container clusters, but the trade-off is you get more control over the infrastructure.
+Unlike ECS tasks and services (which are a bit more "serverless"), we manage the EC2 instances ourselves that are used to host our ECS container instances. However, you get all the normal features of EC2, including auto-scaling. You have more work to do to optimize your container clusters, but the trade-off is you get more control over the infrastructure.
 
 image::../_/ec2-container-instances.drawio.svg[]
 

--- a/src/aws/compute/lightsail.adoc
+++ b/src/aws/compute/lightsail.adoc
@@ -2,6 +2,6 @@
 
 *Lightsail* is Amazon's "Simple Cloud Server". It is another compute service that is similar to EC2, but the difference is Lightsail's user interface is much simpler. Lightsail is suitable for customers who do not have a strong background in cloud computing. It can be thought of as a competitor to "no-frills" cloud computing providers like Digital Ocean and Vultr.
 
-On Lightsail, the cost of virtual servers start at $3.50/month for Linux, $8/month for Windows. The costs are generally cheaper than EC2, but there are fewer features. You can still add devices like load balancers in front of Lightsail VMs, but the virtualization system itself does not come with features like auto-scaling.
+On Lightsail, the cost of virtual servers starts at $3.50/month for Linux, $8/month for Windows. The costs are generally cheaper than EC2, but there are fewer features. You can still add devices like load balancers in front of Lightsail VMs, but the virtualization system itself does not come with features like auto-scaling.
 
 Lightsail is a good choice if you do not require the high-end compute power of EC2, and you do not need EC2's advanced optimization features.


### PR DESCRIPTION
Changes to `src/aws/compute/ec2.adoc`:
- "so its only good for simple scripts" → "so it's only good for simple scripts"

Changes to `src/aws/compute/ecs.adoc`:
- "things lke microservices" → "things like microservices"
- "logic grouping" → "logical grouping"
- "we manage ourselves the EC2 instances" → "we manage the EC2 instances ourselves"

Changes to `src/aws/compute/lightsail.adoc`:
- "the cost of virtual servers start at" → "the cost of virtual servers starts at"