### PR TITLE
proof: aws/databases

### DIFF
--- a/src/aws/databases/athena.adoc
+++ b/src/aws/databases/athena.adoc
@@ -14,7 +14,7 @@
 - Apache HBase
 - _Etc._
 
-You will need a Lambda function to connect Athena to your source (if not S3). You then map the data from the source into tables in Athena, and from their it can be queried.
+You will need a Lambda function to connect Athena to your source (if not S3). You then map the data from the source into tables in Athena, and from there it can be queried.
 
 Athena can query data in CSV, TSV, JSON, Parquet, and ORC formats.
 

--- a/src/aws/databases/dynamodb.adoc
+++ b/src/aws/databases/dynamodb.adoc
@@ -1,6 +1,6 @@
 = AWS DynamoDB
 
-*DynamoDB* is a fully-managed, serverless, NoSQL database services with *in-memory performance*, *low latency* (in milliseconds), *high I/O*, and both dynamic *auto-scaling* or manual *push-button scaling* with no downtime. It can be very cost effective for many storage use cases.
+*DynamoDB* is a fully-managed, serverless, NoSQL database service with *in-memory performance*, *low latency* (in milliseconds), *high I/O*, and both dynamic *auto-scaling* or manual *push-button scaling* with no downtime. It can be very cost effective for many storage use cases.
 
 DynamoDB can be used as both a *key-value store* and as a *document database*. The core components are:
 
@@ -9,7 +9,7 @@ DynamoDB can be used as both a *key-value store* and as a *document database*. T
 * *Attributes* (each item has one or more attributes)
 
 Data is stored in *partitions* that are replicated across multiple availability zones in a region.
-As you data grows, it automatically gets stored across more partitions — so maintaining durability and redundancy at scale. Scaling happens without downtime.
+As your data grows, it automatically gets stored across more partitions — so maintaining durability and redundancy at scale. Scaling happens without downtime.
 
 When you adjust the performance characteristics of your database, AWS automatically adjusts how data is stored to optimize read and write performance as you require.
 
@@ -17,7 +17,7 @@ When you adjust the performance characteristics of your database, AWS automatica
 
 .Key features
 ****
-* *Serverless*: Fully-managed, fault-tolerant, serverles.
+* *Serverless*: Fully-managed, fault-tolerant, serverless.
 
 * *High availability*: 99.99% availability; SLA of 99.999% for global tables.
 
@@ -38,7 +38,7 @@ When you adjust the performance characteristics of your database, AWS automatica
 
 Pricing can be based on either provisioned throughput or on-demand capacity.
 
-The first option means you choose a *provisioned capacity* and you pay for the volume of reads and writes that you have allocated. This is a good option when you understand the performance requirements ad usage patterns of your application.
+The first option means you choose a *provisioned capacity* and you pay for the volume of reads and writes that you have allocated. This is a good option when you understand the performance requirements and usage patterns of your application.
 
 Otherwise, choose *on-demand capacity*. You will pay for the _actual_ read and write operations performed, without needing to worry about capacity planning.
 

--- a/src/aws/databases/elasticache.adoc
+++ b/src/aws/databases/elasticache.adoc
@@ -2,7 +2,7 @@
 
 *ElastiCache* is an *in-memory database* for fast, temporary storage of small amounts of data. It is very useful for speeding up access to data. It tends to be used in front of another DBMS, like RDS.
 
-ElastiCache is basically a fully-managed implementation of Redis and Memcached (which are open source alternatives). As an in-memory store, if gives very high performance and low latency.
+ElastiCache is basically a fully-managed implementation of Redis and Memcached (which are open source alternatives). As an in-memory store, it gives very high performance and low latency.
 
 There are many use cases for putting in-memory caches between applications and their databases. Caching recurring queries is the obvious one. Another use case would be persistent session information for stateful applications, so that sessions can be restored by a failover even if the primary server goes down. Another use case could be to provide a landing spot for streaming sensor data from a factory floor, and serving that data to real-time dashboards.
 

--- a/src/aws/databases/glue.adoc
+++ b/src/aws/databases/glue.adoc
@@ -4,6 +4,6 @@
 
 AWS Glue runs the ETL jobs on a fully-managed, scale-out Apache Spark environment. (You could also use Apache Hive for this purpose.)
 
-AWS Glue discovers data and stores the associated metadata (eg. table definition and schema) in the AWS Glue Data Catalog. You can use a *crawler* to populate the AWS Glue Data Catalog with data tables. A crawler can crawl multiple data stores in a single run. Upon completion, the crawler create or updates one or more tables in your Data Catalog.
+AWS Glue discovers data and stores the associated metadata (eg. table definition and schema) in the AWS Glue Data Catalog. You can use a *crawler* to populate the AWS Glue Data Catalog with data tables. A crawler can crawl multiple data stores in a single run. Upon completion, the crawler creates or updates one or more tables in your Data Catalog.
 
 It works with data lakes (eg. data in S3), data warehouses (including Redshift), and data stores (including RDS and other EC2-hosted databases).


### PR DESCRIPTION
Changes to `src/aws/databases/athena.adoc`:
- "from their it can be queried" → "from there it can be queried"

Changes to `src/aws/databases/dynamodb.adoc`:
- "NoSQL database services" → "NoSQL database service"
- "As you data grows" → "As your data grows"
- "serverles" → "serverless"
- "requirements ad usage patterns" → "requirements and usage patterns"

Changes to `src/aws/databases/elasticache.adoc`:
- "if gives very high performance" → "it gives very high performance"

Changes to `src/aws/databases/glue.adoc`:
- "the crawler create or updates" → "the crawler creates or updates"