### PR TITLE
proof: aws/databases (part 2)

### DIFF
--- a/src/aws/databases/memorydb.adoc
+++ b/src/aws/databases/memorydb.adoc
@@ -4,11 +4,11 @@ This is a Redis-compatible, durable, low-latency, in-memory database service.
 
 The entire dataset is stored in memory, but also persisted on disk. It is a complete database + cache solution — ie. both the database and its cache are bundled together into a single product. This is what distinguished this service from ElastiCache, which is only an in-memory caching system that would typically sit in front of another database system, and it caches query results rather than the underlying data itself.
 
-This services uses Redis data structures, APIs, and commands — it is fully compatible with Redis, making it easy to migrate from that open source solution to this managed service.
+This service uses Redis data structures, APIs, and commands — it is fully compatible with Redis, making it easy to migrate from that open source solution to this managed service.
 
 This service offers microsecond reads and single-digit millisecond write latency, _and_ high throughput. It's actually a higher performance option (ie. lower latency) than even ElastiCache.
 
 Data is stored durably across multiple AZs, using a distributed transactional log.
 
-Write scaling is supported through sharding, and read scaling by adding read replicas. MemoryDB also offers strong consistency for primary nodes, and eventual consistency for replica nodes. By comparison, with ElastiCache, there can be some inconsistency and latency, depending on the endgine and caching strategy you choose, eg. write-through versus lazy loading.
+Write scaling is supported through sharding, and read scaling by adding read replicas. MemoryDB also offers strong consistency for primary nodes, and eventual consistency for replica nodes. By comparison, with ElastiCache, there can be some inconsistency and latency, depending on the engine and caching strategy you choose, eg. write-through versus lazy loading.
 

--- a/src/aws/databases/msk.adoc
+++ b/src/aws/databases/msk.adoc
@@ -12,7 +12,7 @@ Components of MSK include:
 
 * *Producers*: Kafka clients that publish data to topics.
 
-* *Consumers*: Kafka client that read data from topics
+* *Consumers*: Kafka clients that read data from topics
 
 * *Kafka clusters*: At the core of MSK is a set of Kafka brokers, coordinated by Zookeeper nodes.
 

--- a/src/aws/databases/opensearch.adoc
+++ b/src/aws/databases/opensearch.adoc
@@ -12,7 +12,7 @@ To deploy an OpenSearch service:
 
 OpenSearch clusters are deployed into a VPC. Nodes can be replicated across AZs. You can scale out by simply adding more instances into the cluster.
 
-Data can be integrated from various source, including:
+Data can be integrated from various sources, including:
 
 * Kinesis Firehose
 * Logstash
@@ -25,10 +25,10 @@ Alternatively, you can deploy a cluster into the public domain, outside of your 
 When deployed into a VPC, you cannot use IP-based access policies for the cluster. There are also other limitations of VPC deployments:
 
 * You can't switch later from a VPC to a public endpoint, or vice versa.
-* You can't launch your domain within a VPC that used dedicated tenancy.
+* You can't launch your domain within a VPC that uses dedicated tenancy.
 * After you place a domain within a VPC, you can't move it to a different VPC, but you can change the subnets and security group settings.
 
-Once the data sources are connecting, you might then use an open source tool like Kibana to search, analyze, and visualize that data.
+Once the data sources are connected, you might then use an open source tool like Kibana to search, analyze, and visualize that data.
 
 == OpenSearch best practices
 

--- a/src/aws/databases/rds.adoc
+++ b/src/aws/databases/rds.adoc
@@ -6,7 +6,7 @@ RDS is a good choice if you just need a traditional relational database. RDS sup
 
 * *MySQL* and *MariaDB*: MySQL is one of the most popular open source relational database management systems. MariaDB is a community-maintained fork of MySQL.
 
-* *PostgreSQL*: Advanced open source relational database management systems, which supports both relational (SQL) and non-relational (JSON) queries.
+* *PostgreSQL*: Advanced open source relational database management system, which supports both relational (SQL) and non-relational (JSON) queries.
 
 * *Aurora*: This is Amazon's proprietary database engine, which is very scalable, very fast, and cost efficient. It is compatible with both MySQL and PostgreSQL databases.
 
@@ -14,14 +14,14 @@ RDS is a good choice if you just need a traditional relational database. RDS sup
 
 * *Microsoft SQL Server*: Several editions are supported.
 
-RDS runs in EC2 instances. So you need to choose your instance type when you launch a new RDS database. A single EC2 instance may hold one or more user-defined databases.
+RDS runs in EC2 instances. So you need to choose an instance type when you launch a new RDS database. A single EC2 instance may hold one or more user-defined databases.
 
-RDS can be scaled _up_ by upgrading the instance type in the normal way. For example, you might need to scale up to achieve better write performance. Scaling up requires an outage, as you will need to shutdown then restart the newly-upgraded instance. (By comparison, DynamoDB allows you to dynamically modify its performance while the DB continues to run.)
+RDS can be scaled _up_ by upgrading the instance type in the normal way. For example, you might need to scale up to achieve better write performance. Scaling up requires an outage, as you will need to shut down then restart the newly-upgraded instance. (By comparison, DynamoDB allows you to dynamically modify its performance while the DB continues to run.)
 
-RDS also supports horizontal scaling. This is done by creating *read replicas* of your write database (there is always one *primary instance*, and it is always the *write* database). This requires your application being configured to interact with the appropriate database instance, depending on the operating being performed. You can't scale out the write operations — this is a solution for read-heavy workloads only.
+RDS also supports horizontal scaling. This is done by creating *read replicas* of your write database (there is always one *primary instance*, and it is always the *write* database). This requires your application to be configured to interact with the appropriate database instance, depending on the operation being performed. You can't scale out the write operations — this is a solution for read-heavy workloads only.
 
 RDS also has a feature called *Multi-AZ*, in which we have standbys of instances — including the primary write databases — in other availability zones. Replication is synchronous, so the replicas are always up-to-date (writes happen across all replicas at the same time, and the write transaction is not complete until all replicas are updated). Multi-AZ deployments enable automatic disaster recovery. Even if the application is pointing to the primary database, it is actually pointing to an alias. When the primary is down, the alias is automatically redirected to its failover (this is a simple CNAME change). You can even have a read replica take over the role of the primary write database in a disaster recovery event.
 
 Read replicas are synchronized asynchronously. Read replicas could be in the same AZ, a different AZ, or even in a different region.
 
-Like all EC2 instances, EBS volumes are used for storage. Backups are made using EBS snapshots, saved to S2. You can encrypt both your RDS instances and/or their snapshots at rest, using AWS KMS encryption keys.
+Like all EC2 instances, EBS volumes are used for storage. Backups are made using EBS snapshots, saved to S3. You can encrypt both your RDS instances and/or their snapshots at rest, using AWS KMS encryption keys.

--- a/src/aws/databases/redshift.adoc
+++ b/src/aws/databases/redshift.adoc
@@ -2,7 +2,7 @@
 
 *Amazon Redshift* is a fully-managed *data warehouse* solution for Online Analytics Processing (OLAP) use cases on very large volumes of aggregated data, stored in relational formats.
 
-Redshift runs on EC2 instance, so you scale up by changing the instance type in the normal way.
+Redshift runs on EC2 instances, so you scale up by changing the instance type in the normal way.
 
 Redshift automatically keeps three copies of your data, for durability. It can also do continuous, incremental backups.
 


### PR DESCRIPTION
Changes to `src/aws/databases/memorydb.adoc`:
- "This services uses Redis" → "This service uses Redis"
- "endgine and caching strategy" → "engine and caching strategy"

Changes to `src/aws/databases/msk.adoc`:
- "Kafka client that read data" → "Kafka clients that read data"

Changes to `src/aws/databases/opensearch.adoc`:
- "various source" → "various sources"
- "VPC that used dedicated tenancy" → "VPC that uses dedicated tenancy"
- "Once the data sources are connecting" → "Once the data sources are connected"

Changes to `src/aws/databases/rds.adoc`:
- "management systems, which supports" → "management system, which supports"
- "choose your instance type" → "choose an instance type"
- "need to shutdown then restart" → "need to shut down then restart"
- "depending on the operating being performed" → "depending on the operation being performed"
- "saved to S2" → "saved to S3"

Changes to `src/aws/databases/redshift.adoc`:
- "runs on EC2 instance" → "runs on EC2 instances"