### PR TITLE
proof: aws/infrastructure

### DIFF
--- a/src/aws/infrastructure/cloudfront.adoc
+++ b/src/aws/infrastructure/cloudfront.adoc
@@ -19,11 +19,11 @@ Origins, regional edge caches, and edge locations, are connected together by the
 
 Users get routed to their nearest edge location. The only path on the public internet is from the user to the edge location. Everything else is in Amazon's private global network.
 
-CloudFront can deliver both static and dynamic content, and it automatically optimized delivery based on the content type. It even supports live streaming and video-on-demand.
+CloudFront can deliver both static and dynamic content, and it automatically optimizes delivery based on the content type. It even supports live streaming and video-on-demand.
 
 *Lambda@Edge* is a feature of CloudFront that enables the processing of data via Lambda functions that are closer to users.
 
-CloudFront uses HTTPs — so transit of caches between the origin and destinations are encrypted — and it integrates with *AWS Certificate Manager (ACM)* for easy management of the SSL/TLS certificates.
+CloudFront uses HTTPS — so transit of cached data between the origin and destinations is encrypted — and it integrates with *AWS Certificate Manager (ACM)* for easy management of the SSL/TLS certificates.
 
 CloudFront also integrates with *AWS Shield* (for DDoS protection) and *AWS Web Application Firewall (WAF)* (via which you create rules to protect against malicious web traffic) for additional security. Content can also be protected with features like signed cookies, signed URLs, and origin access identity (OAI).
 

--- a/src/aws/infrastructure/public-private-spaces.adoc
+++ b/src/aws/infrastructure/public-private-spaces.adoc
@@ -4,4 +4,4 @@ In the AWS Cloud we say that some services are in the public space while others 
 
 *Public space* services include S3, DynamoDB. Route53, and CloudFront. These services are publicly accessible via the internet by default, ie. they have public APIs.
 
-*Private space* services are those that are launched into VPCs. They include EC2 instances, RDS, and EFS. The resources launched by these services are not accessible from the internet by default. However, you may assigned these resources public IP addresses and then use an internet Gateway to route traffic to them. This is how private space resources are made publicly accessible.
+*Private space* services are those that are launched into VPCs. They include EC2 instances, RDS, and EFS. The resources launched by these services are not accessible from the internet by default. However, you may assign these resources public IP addresses and then use an Internet Gateway to route traffic to them. This is how private space resources are made publicly accessible.

--- a/src/aws/infrastructure/regions-zones.adoc
+++ b/src/aws/infrastructure/regions-zones.adoc
@@ -2,7 +2,7 @@
 
 *AWS regions* are geographical areas around the world.
 
-Each region has multiple, isolated locations known as *availability zones (AZs)*. There are usually three AZs per regions (some have two, and some regions have more than three). The AZs within a region are physically isolated from one another, but they are geographically close enough together to provide very low latency between AZs in the same region.
+Each region has multiple, isolated locations known as *availability zones (AZs)*. There are usually three AZs per region (some have two, and some regions have more than three). The AZs within a region are physically isolated from one another, but they are geographically close enough together to provide very low latency between AZs in the same region.
 
 Regions are further apart and, although they are connected by the AWS global network, latency between regions is higher than between AZs in the same region.
 
@@ -16,6 +16,6 @@ Nevertheless, an AZ represents a single-point-of-failure. A common strategy, the
 
 But for disaster recovery you would also want to replicate resources and data across regions.
 
-There is also something called as a *local zone*, which is a bit like an availability zone, but is usually located in a metropolitan area. The purpose of local zones is to provide lower latency to end-users in the local area. The cost to launch resources into local zones is a bit higher than for availability zones.
+There is also something called a *local zone*, which is a bit like an availability zone, but is usually located in a metropolitan area. The purpose of local zones is to provide lower latency to end-users in the local area. The cost to launch resources into local zones is a bit higher than for availability zones.
 
 There are also *wavelength zones*, which are used for 5G. If you have mobile applications that you want to make available over the 5G network, you can deploy your applications into a wavelength zone, so reducing latency for mobile users.


### PR DESCRIPTION
Changes to `src/aws/infrastructure/cloudfront.adoc`:
- "it automatically optimized delivery" → "it automatically optimizes delivery"
- "CloudFront uses HTTPs" → "CloudFront uses HTTPS"
- "transit of caches... are encrypted" → "transit of cached data... is encrypted"

Changes to `src/aws/infrastructure/public-private-spaces.adoc`:
- "you may assigned" → "you may assign"

Changes to `src/aws/infrastructure/regions-zones.adoc`:
- "three AZs per regions" → "three AZs per region"
- "called as a local zone" → "called a local zone"