### PR TITLE
proof: aws/logging

### DIFF
--- a/src/aws/logging/cloudtrail.adoc
+++ b/src/aws/logging/cloudtrail.adoc
@@ -8,4 +8,4 @@ By default, management events are logged and retained for 90 days. But if we cre
 
 *CloudWatch Events* can be triggered based on API calls made to CloudTrail. So, when we record in CloudTrail a certain event, we can have CloudWatch Events trigger something based on that.
 
-CloudTrail events cna also be streamed to CloudWatch Logs.
+CloudTrail events can also be streamed to CloudWatch Logs.

--- a/src/aws/logging/vpc-flow-logs.adoc
+++ b/src/aws/logging/vpc-flow-logs.adoc
@@ -4,7 +4,7 @@
 
 They are not a security feature, but rather a monitoring feature.
 
-This is about logging what happens in an account's networks — at the VPC, subnet, and instance levels (or, correctly, the network interfaces attached to EC2 instances). You can inspect the logs at those three levels, or all of them, and I can output the logs to CloudWatch Logs or S3.
+This is about logging what happens in an account's networks — at the VPC, subnet, and instance levels (or, correctly, the network interfaces attached to EC2 instances). You can inspect the logs at those three levels, or all of them, and you can output the logs to CloudWatch Logs or S3.
 
 VPC Flow Logs provide *visibility* of network traffic and support *troubleshooting* and *forensics* of network traffic.
 


### PR DESCRIPTION
Changes to `src/aws/logging/cloudtrail.adoc`:
- "events cna also be streamed" → "events can also be streamed"

Changes to `src/aws/logging/vpc-flow-logs.adoc`:
- "and I can output the logs" → "and you can output the logs"