### PR TITLE
proof: aws/miscellany

### DIFF
--- a/src/aws/miscellany/amplify-appsync.adoc
+++ b/src/aws/miscellany/amplify-appsync.adoc
@@ -6,7 +6,7 @@
 
 *AWS Amplify Hosting* is a fully-managed CI/CD and hosting service for fast, secure, and reliable static and server-side rendered apps.
 
-*AWS AppSync* is a fully-managed services that makes it easy to develop GraphQL APIs. Applications can securely access, manipulate, and receive real-time updates from multiple data sources — which could be AWS Lambda, Aurora, DynamoDB, Elasticsearch, HTTP, etc.
+*AWS AppSync* is a fully-managed service that makes it easy to develop GraphQL APIs. Applications can securely access, manipulate, and receive real-time updates from multiple data sources — which could be AWS Lambda, Aurora, DynamoDB, Elasticsearch, HTTP, etc.
 
 AppSync automatically scales the GraphQL API execution engine to meet API request volumes dynamically.
 

--- a/src/aws/miscellany/iot-core.adoc
+++ b/src/aws/miscellany/iot-core.adoc
@@ -4,4 +4,4 @@ The Internet of Things (IoT) describes a network of physical objects that are em
 
 AWS IoT Core lets you connect IoT devices to the AWS cloud without the need to provision or manage servers. It can support billions of devices and trillions of messages.
 
-Messages are transmitted and received using the MQTT (Message Queuing Telemetry Transport) protocol, which minimizes the code footprint on the device and reduces network bandwidth requirements. Devices publish and subscribe to messages by topic. AWS IOT Core allows devices to communicate with AWS services and/or each other.
+Messages are transmitted and received using the MQTT (Message Queuing Telemetry Transport) protocol, which minimizes the code footprint on the device and reduces network bandwidth requirements. Devices publish and subscribe to messages by topic. AWS IoT Core allows devices to communicate with AWS services and/or each other.

--- a/src/aws/miscellany/migration-and-transfer.adoc
+++ b/src/aws/miscellany/migration-and-transfer.adoc
@@ -10,7 +10,7 @@ There is also an *AWS Server Migration Service (SMS)*, and a *VM Import/Export* 
 
 The *AWS Database Migration Service (DMS)* can help you migrate databases to RDS, Aurora, RedShift, or other solutions. It includes a *Schema Conversion Tool* to help convert database schemas in heterogeneous migrations.
 
-And *AWS DataSync* can be used to help us transfer data from network-attached storage (NAS) or file server, into S3 or EFS, for example. For large-scale data transfer there is the Snowball family — see below.
+And *AWS DataSync* can be used to help you transfer data from network-attached storage (NAS) or a file server, into S3 or EFS, for example. For large-scale data transfer there is the Snowball family — see below.
 
 Finally, there's *AWS Migration Hub* which helps you to manage the actual migration process and visualize what's happening.
 
@@ -18,7 +18,7 @@ Finally, there's *AWS Migration Hub* which helps you to manage the actual migrat
 
 For advanced data migration, there is the Snowball family.
 
-These are physical devices used for migrating very large amounts of data into AWS. You connect the device to your own data center, you load the data on to it, and physically send it back to AWS. So this family of products is used to provide the secure _physical_ transfer of data between two locations.
+These are physical devices used for migrating very large amounts of data into AWS. You connect the device to your own data center, you load the data onto it, and physically send it back to AWS. So this family of products is used to provide the secure _physical_ transfer of data between two locations.
 
 The "Snowball" devices come in sizes of 50TB and 80TB, while "Snowball Edge" is 100TB — this is known as "petabyte scale". There's also "Snowmobile" which is up to 100PB, known as "exabyte scale". This is literally a shipping container that sits on the back of a truck!
 


### PR DESCRIPTION
Changes to `src/aws/miscellany/amplify-appsync.adoc`:
- "fully-managed services that makes" → "fully-managed service that makes"

Changes to `src/aws/miscellany/iot-core.adoc`:
- "AWS IOT Core" → "AWS IoT Core"

Changes to `src/aws/miscellany/migration-and-transfer.adoc`:
- "help us transfer data... or file server" → "help you transfer data... or a file server"
- "load the data on to it" → "load the data onto it"