### PR TITLE
proof: aws/networking

### DIFF
--- a/src/aws/networking/ip-addresses.adoc
+++ b/src/aws/networking/ip-addresses.adoc
@@ -22,7 +22,7 @@ Public IP addresses are free of charge.
 
 An instance launched into a public subnet has both a public IP address and a private IP address. An instance's public and private IP addresses are associated with each other.
 
-An instance's public IP address is used to communicate with the instance from outside the VPC. It's private IP address is used for communication from other resources within the VPC.
+An instance's public IP address is used to communicate with the instance from outside the VPC. Its private IP address is used for communication from other resources within the VPC.
 
 Thus, every resource within a VPC has a private IP address. Instances launched into a private subnet will have only a private IP address, and not a public (or elastic one). You cannot assign public or elastic IP addresses to resources launched into private subnets.
 
@@ -34,7 +34,7 @@ Private IP addresses are also free of charge.
 
 == Elastic IP addresses
 
-This is Amazon's name for *static public IP addresses*. You rent them from AWS, and they are not automatically assigned to resources. If you assign an elastic IP address to a resource, and then later drop the resource, the elastic IP address will be returned to your account's pool of available elastic IP addresses available. You can then reuse the static IP address for new resources.
+This is Amazon's name for *static public IP addresses*. You rent them from AWS, and they are not automatically assigned to resources. If you assign an elastic IP address to a resource, and then later drop the resource, the elastic IP address will be returned to your account's pool of available elastic IP addresses. You can then reuse the static IP address for new resources.
 
 With elastic IP addresses, you also have the flexibility to move the addresses between EC2 instances (and also Elastic Network Adapters).
 
@@ -42,7 +42,7 @@ As with standard public IP addresses, static public addresses are associated wit
 
 You are not charged for _using_ elastic IP address, but you are charged for _not using_ them. This is indented to discourage hoarding of public IPv4 addresses, which are in short supply.
 
-Static IP address can be useful where you want to have a fixed address for a resource, for example for the purpose of allow-listing a resource in a firewall configuration. However, generally you want to avoid depending on static IP address, and instead use DNS names that can be resolved to different addresses.
+Static IP addresses can be useful where you want to have a fixed address for a resource, for example for the purpose of allow-listing a resource in a firewall configuration. However, generally you want to avoid depending on static IP address, and instead use DNS names that can be resolved to different addresses.
 
 image::../_/aws-ec2-instance-in-public-subnet.drawio.svg[]
 

--- a/src/aws/networking/nacls.adoc
+++ b/src/aws/networking/nacls.adoc
@@ -20,7 +20,7 @@ NACLs should be relatively short; if you find your NACLs have grown, with lots o
 ****
 image::../_/stateless-firewall.drawio.svg[]
 
-The server is listening on port 80 for incoming connections. This is the "destination port" for client requests. A client making a request to the server assigns its own "source port" — this is dynamically allocated by the OS of the client machine and is a high-numbered port rather than one of the standard low-level ports in the range 1 - 1,124.
+The server is listening on port 80 for incoming connections. This is the "destination port" for client requests. A client making a request to the server assigns its own "source port" — this is dynamically allocated by the OS of the client machine and is a high-numbered port rather than one of the standard low-level ports in the range 1 – 1,023.
 
 When a server receives a request, it may create a second connection to the client and use it to send a response back to the client. The server's response is sent to the same port the client used to make the initial request. This becomes the destination port for the server's response.
 

--- a/src/aws/networking/route-tables.adoc
+++ b/src/aws/networking/route-tables.adoc
@@ -17,7 +17,7 @@ In the above route table, `172.31.0.0/16` is the CIDR block, ie. the overall IP 
 
 The second routing rule says that any other traffic must be routed out to the internet gateway. This is how EC2 instances within the VPC can communicate with the outside world.
 
-In the previous step we'd implemented the following architecture. But we cannot yet SSH into the instance in the public subnet because there is no *route* to the public subnet from the internet gateway attached the VPC>
+In the previous step we'd implemented the following architecture. But we cannot yet SSH into the instance in the public subnet because there is no *route* to the public subnet from the internet gateway attached to the VPC.
 
 image::../_/aws-networking-3.drawio.svg[]
 

--- a/src/aws/networking/security-groups.adoc
+++ b/src/aws/networking/security-groups.adoc
@@ -10,7 +10,7 @@ image::../_/aws-networking-8.drawio.svg[]
 
 Strictly speaking, security groups are not attached to instances, but rather are attached to the *Elastic Network Interface (ENI)* of the adapters that connect to the instances.
 
-Unlike a NACL, a security group is stateful. If some traffic is allowed through by an inbound rule, its going to remember that state and allow the response out.
+Unlike a NACL, a security group is stateful. If some traffic is allowed through by an inbound rule, it's going to remember that state and allow the response out.
 
 A common pattern for security groups is to have one security group for the "frontend" web servers, one for the "backend" application servers, and perhaps also another for the database servers. The frontend security group would allow traffic on `0.0.0.0/0` (meaning everything). But for the backend security group you might add a rule that says: "Only allow communication from the WebServerSecurityGroup."
 
@@ -47,6 +47,6 @@ This is an important feature of security groups: you can explicitly allow traffi
 
 [NOTE]
 ======
-Neither security groups nor NACLs will filter traffic to or from link-local addresses (`169.254.0.0/16` or AWS-reserved IPv4 addresses (these are the first four IPv4 addresses of the subnet, one ofw which is allocated to the VPC's DNS server).
+Neither security groups nor NACLs will filter traffic to or from link-local addresses (`169.254.0.0/16` or AWS-reserved IPv4 addresses (these are the first four IPv4 addresses of the subnet, one of which is allocated to the VPC's DNS server).
 ======
 ****

--- a/src/aws/networking/subnets.adoc
+++ b/src/aws/networking/subnets.adoc
@@ -1,6 +1,6 @@
 = AWS networking: Subnets
 
-Within a VPC you will have isolated networks called *subnets*. A subset is a defined range of network IP addresses — an *IP space* — within a VPC's CIDR range.
+Within a VPC you will have isolated networks called *subnets*. A *subnet* is a defined range of network IP addresses — an *IP space* — within a VPC's CIDR range.
 
 Subnets are used to increase the security and efficiency of network communications. You can think of them as like postcodes, which help to route mail in a more efficient way than could be achieved using only the street address and city.
 

--- a/src/aws/networking/transit-gateways.adoc
+++ b/src/aws/networking/transit-gateways.adoc
@@ -2,7 +2,7 @@
 
 A *transit gateway (TGW)* is another type of networking device. It is useful where you want to connect lots and lots of VPCs, and perhaps even on-premises networks, without needing to explicitly configure all of the possible individual routes.
 
-A transit gateway is a *network transit hub* that interconnects VPs and on-premises networks. It is a newer, and more centralized, solution than *VPC peering*, which can be used to achieve the same end goal.
+A transit gateway is a *network transit hub* that interconnects VPCs and on-premises networks. It is a newer, and more centralized, solution than *VPC peering*, which can be used to achieve the same end goal.
 
 image::../_/transit-gateway.drawio.svg[]
 
@@ -10,7 +10,7 @@ TGW is a managed, distributed routing service that you deploy into an AWS region
 
 Besides VPNs in the same region, TGWs can also be used to connect to on-premises networks (via *Direct Connect* gateways), and even to other TGWs in different regions or AWS accounts — which is how hybrid, cross-region, and cross-account VPC networks can be established using transit gateways.
 
-TGWs are easier to manage than VPC peering. VPC route tables have a single entry to the TGW, and then then TGW has its own route table which manages the connections between VPCs. As with VPC peering, intra-VPC communication is private, using private IP connectivity, but the routing rules are now centrally managed by the TGW.
+TGWs are easier to manage than VPC peering. VPC route tables have a single entry to the TGW, and then the TGW has its own route table which manages the connections between VPCs. As with VPC peering, intra-VPC communication is private, using private IP connectivity, but the routing rules are now centrally managed by the TGW.
 
 .VPC peering versus transit gateway
 ****

--- a/src/aws/networking/vpc.adoc
+++ b/src/aws/networking/vpc.adoc
@@ -6,7 +6,7 @@ A VPC is analogous to having your own data center, but in the cloud. A VPC is a 
 
 You get a default VPC as soon as you create a new AWS account.
 
-Any resources you launch into a VPC will be visible only to your AWS account by default. Resources launched in different VPCs under the same account will be hidden from each other — unless you explicitly configure them to communicate with each other. This is the primary purpose of VPCs: to created logically-isolated groups of resources.
+Any resources you launch into a VPC will be visible only to your AWS account by default. Resources launched in different VPCs under the same account will be hidden from each other — unless you explicitly configure them to communicate with each other. This is the primary purpose of VPCs: to create logically-isolated groups of resources.
 
 A VPC is region-specific, meaning it is created within a single AWS region. A VPC will span all the availability zones (AZs) within the same region (there's usually two or three) — in effect, spanning multiple data centers that are geographically close together. This allows resources to be distributed across multiple AZs, adding redundancy to your architecture to achieve high availability and fault tolerance (if one AZ goes down, you can failover to resources in other AZs in the same region). Distributing load across multiple AZs also allows for better resource balancing and scaling.
 


### PR DESCRIPTION
Changes to `src/aws/networking/ip-addresses.adoc`:
- "It's private IP address" → "Its private IP address"
- Removed redundant "available" at end of sentence about elastic IP pool
- "Static IP address can be useful" → "Static IP addresses can be useful"

Changes to `src/aws/networking/nacls.adoc`:
- "NACLS do not screen" → "NACLs do not screen"
- "range 1 - 1,124" → "range 1 – 1,023"

Changes to `src/aws/networking/route-tables.adoc`:
- "internet gateway attached the VPC\u003e" → "internet gateway attached to the VPC"

Changes to `src/aws/networking/security-groups.adoc`:
- "its going to remember" → "it's going to remember"
- "one ofw which" → "one of which"

Changes to `src/aws/networking/subnets.adoc`:
- "A subset is a defined range" → "A subnet is a defined range"

Changes to `src/aws/networking/transit-gateways.adoc`:
- "interconnects VPs" → "interconnects VPCs"
- "and then then TGW" → "and then the TGW"

Changes to `src/aws/networking/vpc.adoc`:
- "to created logically-isolated" → "to create logically-isolated"