### PR TITLE
proof: aws/routing

### DIFF
--- a/src/aws/routing/auto-scaling.adoc
+++ b/src/aws/routing/auto-scaling.adoc
@@ -6,13 +6,13 @@ In AWS, auto-scaling is primarily a feature of EC2, but by extension is also app
 
 Auto-scaling integrates with lots of other AWS services, including:
 
-* *CloudWatch* for monitoring. Instances constantly send information to CloudWatch — things like metrics on the CPU utilization — which can be used by auto-scaling to determine whether to scale  the cluster out or in, so adding or terminating individual nodes.
+* *CloudWatch* for monitoring. Instances constantly send information to CloudWatch — things like metrics on the CPU utilization — which can be used by auto-scaling to determine whether to scale the cluster out or in, so adding or terminating individual nodes.
 
 * *Elastic Load Balancing* for distributed connections, so the LB automatically knows about changes in instances to which it can distribute traffic.
 
 * *VPC*, because we want to deploy new instances within the VPC and across availability zones.
 
-Auto-scaling working like this:
+Auto-scaling works like this:
 
 * Across AZs, we define an *auto-scaling group (ASG)*.
 

--- a/src/aws/routing/load-balancers.adoc
+++ b/src/aws/routing/load-balancers.adoc
@@ -14,7 +14,7 @@ An ELB instance is a single IP endpoint — a DNS name or IP address — behind 
 * Lambda functions.
 * Other load balancers (you can chain LBs together — there are some use cases where this can be advantageous).
 
-Load balancers implement their own health checks on their targets, and they will send traffic only to healthy instances. If an instance becomes unhealthy, the ELB will stop sending traffic to it until it becomes healthy again. An ELB can also tell an Auto-Scaling Group to replace failing instances, and in turn the ASG tells ELBs about new instances that is creates, and old ones it has terminated.
+Load balancers implement their own health checks on their targets, and they will send traffic only to healthy instances. If an instance becomes unhealthy, the ELB will stop sending traffic to it until it becomes healthy again. An ELB can also tell an Auto-Scaling Group to replace failing instances, and in turn the ASG tells ELBs about new instances that it creates, and old ones it has terminated.
 
 If an ELB sits in front of multiple availability zones, then the Auto-Scaling Group should also span the same AZs. ASGs try to spread load across multiple AZs, while ELBs distribute connectivity to all the available instances across all those AZs.
 


### PR DESCRIPTION
Changes to `src/aws/routing/auto-scaling.adoc`:
- "to maintaining a steady state" → "to maintain a steady state"
- "Auto-scaling working like this" → "Auto-scaling works like this"
- "to scale  the cluster" → "to scale the cluster"

Changes to `src/aws/routing/load-balancers.adoc`:
- "new instances that is creates" → "new instances that it creates"