### PR TITLE
proof: aws/services

### DIFF
--- a/src/aws/services/api-gateway.adoc
+++ b/src/aws/services/api-gateway.adoc
@@ -6,4 +6,4 @@ An API Gateway sits within a region. We can connect to it over the internet usin
 
 An API Gateway may forward requests to, for example, Lambda functions (in the same region) or EC2 instances (in a VPC in the same region).
 
-You can talk to almost any other AWS service from an API Gateway. An API Gateway can also talk _out_ to other public API endpoints served from elsewhere on the web, which could be a service being served from an on-premised data center. Thus, an API Gateway can sit in front of both internal and external services.
+You can talk to almost any other AWS service from an API Gateway. An API Gateway can also talk _out_ to other public API endpoints served from elsewhere on the web, which could be a service being served from an on-premises data center. Thus, an API Gateway can sit in front of both internal and external services.

--- a/src/aws/services/event-bridge.adoc
+++ b/src/aws/services/event-bridge.adoc
@@ -19,4 +19,4 @@ Which targets receive the events is determined by *rules* that you define in the
 
 SNS is often used as a target, where you want to send notifications for events such as termination of EC2 instances.
 
-EventBridge is intended to be used as the backbone for event-driven application, responsible for processing state changes in application resources. But it is a very versatile system and can really be used for managing all sorts of events at both the application and system levels.
+EventBridge is intended to be used as the backbone for event-driven applications, responsible for processing state changes in application resources. But it is a very versatile system and can really be used for managing all sorts of events at both the application and system levels.

--- a/src/aws/services/lambda.adoc
+++ b/src/aws/services/lambda.adoc
@@ -1,16 +1,16 @@
 = AWS Lambda
 
-*AWS Lambda* is a store of function. A function is evoked in in response to some kind of trigger, which is communicated via an event.
+*AWS Lambda* is a store of function. A function is invoked in response to some kind of trigger, which is communicated via an event.
 
 An event could come from any other AWS service or resource. Alternatively, an event could be a direct invocation of a Lambda function via the AWS API.
 
-Functions can be invoked synchronously or asynchronously. With *synchronous* invocation, applications wait for the function to process the event and return a response (a success or failure outcome). With *asynchronous* invocation, Lambda queues the event for processing and returns a response immediately — just to acknowledge it has received the invocation requests. The client is not automatically informed of the outcome of the function's invocation (you will have to setup another chain of events if you want this information to make its way back to the application).
+Functions can be invoked synchronously or asynchronously. With *synchronous* invocation, applications wait for the function to process the event and return a response (a success or failure outcome). With *asynchronous* invocation, Lambda queues the event for processing and returns a response immediately — just to acknowledge it has received the invocation requests. The client is not automatically informed of the outcome of the function's invocation (you will have to set up another chain of events if you want this information to make its way back to the application).
 
 If the code run by a Lambda function accesses other AWS services and resources, IAM roles should be used to give the function the necessary permissions.
 
-Lambda functions are regional, and so they do not have access to VPCs by default. If we want a function to have access to a resource in a VPC, such as an EC2 instance, we have to comment the Lambda function to the VPC. Then, from Lambda, you select the VPC, subnet, and security groups, and then Lambda will create an *Elastic Network Interface (ENI)* in those subnets. The function will also need to have the relevant permissions to create the ENI, so that permission must be in the policy of the role used to execute the function.
+Lambda functions are regional, and so they do not have access to VPCs by default. If we want a function to have access to a resource in a VPC, such as an EC2 instance, we have to connect the Lambda function to the VPC. Then, from Lambda, you select the VPC, subnet, and security groups, and then Lambda will create an *Elastic Network Interface (ENI)* in those subnets. The function will also need to have the relevant permissions to create the ENI, so that permission must be in the policy of the role used to execute the function.
 
-If a Lambda function is required to call out to the wider internet, a NAT gateway will be required. This will be the part of the VPC that the Lambda function connects too. The NAT gateway would need to be deployed into a public subnet with the VPC.
+If a Lambda function is required to call out to the wider internet, a NAT gateway will be required. This will be the part of the VPC that the Lambda function connects to. The NAT gateway would need to be deployed into a public subnet with the VPC.
 
 Pricing is based on the memory assigned to functions by you, and the duration of the function execution. You assign memory to a function, but Lambda will then allocate a proportional amount of compute power (CPU). Billing is done by the millisecond of usage.
 


### PR DESCRIPTION
Changes to `src/aws/services/api-gateway.adoc`:
- "an on-premised data center" → "an on-premises data center"

Changes to `src/aws/services/event-bridge.adoc`:
- "backbone for event-driven application" → "backbone for event-driven applications"

Changes to `src/aws/services/lambda.adoc`:
- "A function is evoked in in" → "A function is invoked in"
- "you will have to setup another chain" → "you will have to set up another chain"
- "we have to comment the Lambda function" → "we have to connect the Lambda function"
- "Lambda function connects too" → "Lambda function connects to"