### PR TITLE
proof: aws/ui

### DIFF
--- a/src/aws/ui/cli.adoc
+++ b/src/aws/ui/cli.adoc
@@ -4,7 +4,7 @@ To use the *AWS CLI*, you need to authenticate with a user that has *access keys
 
 You can create access keys via the Identity and Access Management (IAM) service. In the IAM web console, go to *Security credentials* for your user, then *Access keys* > *Create access key*. Follow the steps to generate an access key.
 
-Then the the following from your terminal:
+Then run the following from your terminal:
 
 [source,sh]
 ----


### PR DESCRIPTION
Changes to `src/aws/ui/cli.adoc`:
- "Then the the following" → "Then run the following"