### PR TITLE
proof: bash

### DIFF
--- a/src/bash/README.adoc
+++ b/src/bash/README.adoc
@@ -25,7 +25,7 @@ See also link:../unix[Unix cheats] for usage of built-in system commands like `g
 * link:./vars/arrays.adoc[Arrays]
 
 == Functions
-`
+
 * link:./fns/declaration.adoc[Declaring functions]
 * link:./fns/invocation.adoc[Invoking functions]
 * link:./fns/parameters.adoc[Function parameters]

--- a/src/bash/conditionals/tests.adoc
+++ b/src/bash/conditionals/tests.adoc
@@ -1,6 +1,6 @@
 = Bash: Tests
 
-The single backet syntax `[ ... ]` is the original test command in Bourne shell. It is POSIX-compliant and works in all POSIX-compliant shells, including Bash.
+The single bracket syntax `[ ... ]` is the original test command in Bourne shell. It is POSIX-compliant and works in all POSIX-compliant shells, including Bash.
 
 [source,bash]
 ----

--- a/src/bash/files/sourcing.adoc
+++ b/src/bash/files/sourcing.adoc
@@ -1,6 +1,6 @@
 = Bash: Sourcing
 
-The process of importing other Bash files is known as sourcing. It is done using the `source keyword followed by a path to the file to import. The path may be absolute, or relative to the current running script (which is not necessarily the current file).
+The process of importing other Bash files is known as sourcing. It is done using the `source` keyword followed by a path to the file to import. The path may be absolute, or relative to the current running script (which is not necessarily the current file).
 
 [source,bash]
 ----

--- a/src/bash/process-management.adoc
+++ b/src/bash/process-management.adoc
@@ -61,7 +61,7 @@ nohup ./my_script.sh &
 
 ----
 
-When you run a command in the background, uou'll see output like `[1] 12345`` where 1 is the job number and 12345 is the process ID (PID). To stop the background job, you can run either of these commands:
+When you run a command in the background, you'll see output like `[1] 12345` where 1 is the job number and 12345 is the process ID (PID). To stop the background job, you can run either of these commands:
 
 [source,bash]
 ----

--- a/src/bash/vars/types.adoc
+++ b/src/bash/vars/types.adoc
@@ -2,6 +2,6 @@
 
 Unix shells don't have formal data types, like high-level programming languages. Instead, every variable value is treated as a string by default.
 
-But there are behaviors that interpret values into other types. For examples, variables are treated as integers when used in arithmetic contexts.
+But there are behaviors that interpret values into other types. For example, variables are treated as integers when used in arithmetic contexts.
 
 Furthermore, community conventions have emerged for simulating other types; for example, the string values `"true"` and `"false"` are commonly used to represent boolean values.


### PR DESCRIPTION
Changes to `src/bash/README.adoc`:
- Removed stray backtick character before the Functions section

Changes to `src/bash/conditionals/tests.adoc`:
- "single backet syntax" → "single bracket syntax"

Changes to `src/bash/files/sourcing.adoc`:
- Fixed missing closing backtick after `source` keyword

Changes to `src/bash/process-management.adoc`:
- "uou'll see output" → "you'll see output"

Changes to `src/bash/vars/types.adoc`:
- "For examples, variables" → "For example, variables"