### PR TITLE
proof: debian

### DIFF
--- a/src/debian/README.adoc
+++ b/src/debian/README.adoc
@@ -22,7 +22,7 @@ To change the root password:
 sudo passwd root
 ----
 
-When you restart, you might see the error "The password you use to login to your computer no longer matches that of your login keyring". This error occurs when your user login password and the saved keyring password (used to auto-unlock stored credentials) become de-synchronized. When you see this message, you can simply enter your _old_ keyring password (which will match your _old_ system password), nd the keyring password will be automatically updated to match your _new_ system password.
+When you restart, you might see the error "The password you use to login to your computer no longer matches that of your login keyring". This error occurs when your user login password and the saved keyring password (used to auto-unlock stored credentials) become de-synchronized. When you see this message, you can simply enter your _old_ keyring password (which will match your _old_ system password), and the keyring password will be automatically updated to match your _new_ system password.
 
 To avoid this error in the first place, change the keyring password to match your current login password using the "Passwords and Keys" (aka. seahorse) app:
 


### PR DESCRIPTION
Changes to `src/debian/README.adoc`:
- ", nd the keyring" → ", and the keyring"