### PR TITLE
proof: docker

### DIFF
--- a/src/docker/commands.adoc
+++ b/src/docker/commands.adoc
@@ -8,7 +8,7 @@ Running the `docker` program without any arguments will display a list of availa
 Build a Docker image from the Dockerfile in the current working directory. See link:./dockerfile.adoc[Dockerfile] for more information on this command.
 
 `docker pull <image-name>(:<tag>)` +
-Pull an pre-built image from a registry (Docker Hub by default).
+Pull a pre-built image from a registry (Docker Hub by default).
 
 `docker search <query>` +
 Search for images on Docker Hub. This is useful to find pre-built images for common technology stacks, eg. `docker search jdk`.
@@ -40,7 +40,7 @@ Docker will generate a random name for a container, unless you specify one using
 By default, `docker run` creates a fresh container from the specified version tag. This means you can end up with lots of unused containers lying around if you do not explicitly delete them later. Commonly, you will only want one container instance per image. Use the `--rm` option to automatically remove existing containers built from the specified image, before building and running a new container.
 
 `docker stop|start|restart <container-id>` +
-The `run` command builds a new container before running it. If you just want to restart a container without rebuilding it every time, use the `stop`, `start`, and `restart` commands after the first `run` operation.Restarted containers will retain the attributes specified when the container was created using `docker run`, such as port bindings.
+The `run` command builds a new container before running it. If you just want to restart a container without rebuilding it every time, use the `stop`, `start`, and `restart` commands after the first `run` operation. Restarted containers will retain the attributes specified when the container was created using `docker run`, such as port bindings.
 
 `docker run -it <image-name>(:<tag>)` +
 Run the container in interactive mode. This allows you to interact with the container's shell. See below for more information on interactive mode. You will typically use interactive mode when running a container in detached mode, so normally you will combine the `-d` and `-it` flags: `docker run -dit <image-name>(:<tag>)`.

--- a/src/docker/compose.adoc
+++ b/src/docker/compose.adoc
@@ -42,7 +42,7 @@ docker compose up
 Because there will be multiple containers, you'd typically run them in detached mode:
 
 ----
-docker compose -d up
+docker compose up -d
 ----
 
 If you change the name of the `docker-compose.yml` file, or if it exists in another directory, you will need to specify the file name in the command, eg.:

--- a/src/docker/networking.adoc
+++ b/src/docker/networking.adoc
@@ -22,16 +22,14 @@ Type `docker network ls` to list Docker's internal networks. Docker auto-generat
 docker network create mongo-network
 ----
 
-We can now run the MongoDB and MongoExpress containers, attaching them to the `mongo-network` network. For MongoDB, we need to specify a container name, as we'll use this to configure the MongoExpress instance so it knows which container is the MongoDB one. We also need to pass in environment variables, which the `mongo` container uses to configuration its MongoDB instance - as https://hub.docker.com/_/mongo[documented here].
+We can now run the MongoDB and MongoExpress containers, attaching them to the `mongo-network` network. For MongoDB, we need to specify a container name, as we'll use this to configure the MongoExpress instance so it knows which container is the MongoDB one. We also need to pass in environment variables, which the `mongo` container uses to configure its MongoDB instance - as https://hub.docker.com/_/mongo[documented here].
 
 ----
 docker run -d \
   -p 27017:27017 \
   -e MONGO_INITDB_ROOT_USERNAME=admin \
   -e MONGO_INITDB_ROOT_PASSWORD=password \
-  --name mongodb
-  --net mongo-network
-  mongo
+  --name mongodb \\n  --net mongo-network \\n  mongo
 ----
 
 Type `docker log <container-id>`, using the output from the previous command to capture the container ID, to check the log output. An entry near the end of the log should read "... waiting for connections ...", indicating that the MongoDB database instance started successfully.


### PR DESCRIPTION
Changes to `src/docker/commands.adoc`:
- "Pull an pre-built image" → "Pull a pre-built image"
- "operation.Restarted containers" → "operation. Restarted containers"

Changes to `src/docker/compose.adoc`:
- "docker compose -d up" → "docker compose up -d"

Changes to `src/docker/networking.adoc`:
- "uses to configuration its MongoDB instance" → "uses to configure its MongoDB instance"
- Fixed missing line continuation backslashes in the docker run command for MongoDB