### PR TITLE
proof: github-actions

### DIFF
--- a/src/github-actions/actions.adoc
+++ b/src/github-actions/actions.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 == Overview
 
-Actions – not be confused with "GitHub Actions", which happens to also be the brand name for the overall CI/CD service offered by GitHub – can be thought of as shareable packaged commands that can be reused across multiple workflows.
+Actions – not to be confused with "GitHub Actions", which happens to also be the brand name for the overall CI/CD service offered by GitHub – can be thought of as shareable packaged commands that can be reused across multiple workflows.
 
 An action is plugged in to a link:./steps.adoc[step] in a link:./jobs.adoc[job]. See links:./steps.adoc[steps] for instructions to call an action from a step.
 

--- a/src/github-actions/caches-artifacts.adoc
+++ b/src/github-actions/caches-artifacts.adoc
@@ -102,7 +102,7 @@ When a workflow produces something other than a log entry, the product is called
 
 Since each job uses a fresh instance of a virtual machine, by default artifacts are not preserved between jobs. Therefore, a job that deploys a container cannot, by default, access the container that was created by the build job.
 
-So preserve artifacts between jobs, the artifacts can be stored. There are a couple of ready-made actions for this purpose:
+To preserve artifacts between jobs, the artifacts can be stored. There are a couple of ready-made actions for this purpose:
 
 * `actions/upload-artifact`
 * `actions/download-artifact`

--- a/src/github-actions/variables.adoc
+++ b/src/github-actions/variables.adoc
@@ -31,7 +31,7 @@ Lower-level secrets override higher-level secrets.
 
 Secret names MUST contain only alphanumeric characters and underscores. Secret names MUST NOT start with number, and names MUST NOT started with the `GITHUB_` prefix, which is reserved.
 
-Names are case-insensitive, and they must be unique at the level they are at which they are declared.
+Names are case-insensitive, and they must be unique at the level at which they are declared.
 
 Secrets can be set via the GitHub web UI or the `gh` CLI tool. To set repository-level secrets:
 

--- a/src/github-actions/workflows.adoc
+++ b/src/github-actions/workflows.adoc
@@ -55,7 +55,7 @@ jobs:
 
 (This example represents a classic use case for reusable workflows: to deploy to different environments while ensuring a similar deployment process for all environments.)
 
-You can also capture outputs from a reusable workflow and use them in the caller workflow. The process is similar to using outputs between different dependent jobs in the same workflow, but here you also have to specify the outputs under the `outputs` keyword in the `workflow_call` event definition, as wells as in the output from jobs within the reusable workflow. The job passes its outputs up to the workflow, and then the `workflow_call` event passes them out to the caller.
+You can also capture outputs from a reusable workflow and use them in the caller workflow. The process is similar to using outputs between different dependent jobs in the same workflow, but here you also have to specify the outputs under the `outputs` keyword in the `workflow_call` event definition, as well as in the output from jobs within the reusable workflow. The job passes its outputs up to the workflow, and then the `workflow_call` event passes them out to the caller.
 
 .Reusable workflow
 [source,yaml]


### PR DESCRIPTION
Changes to `src/github-actions/actions.adoc`:
- "Actions – not be confused" → "Actions – not to be confused"

Changes to `src/github-actions/caches-artifacts.adoc`:
- "So preserve artifacts between jobs" → "To preserve artifacts between jobs"

Changes to `src/github-actions/variables.adoc`:
- "at the level they are at which they are declared" → "at the level at which they are declared"

Changes to `src/github-actions/workflows.adoc`:
- "as wells as" → "as well as"