### PR TITLE
proof: ollama

### DIFF
--- a/src/monit/README.adoc
+++ b/src/monit/README.adoc
@@ -36,7 +36,7 @@ The "with start delay" line prevents Monit from running a test immediately after
 
 == Web interface
 
-Monit comes with its own built-in web server, for displaying the system tests as a web page. Monit's server needs to run on a different port than other web servers running on the same system. FOr this reason, port 2812 is Monit's default port.
+Monit comes with its own built-in web server, for displaying the system tests as a web page. Monit's server needs to run on a different port than other web servers running on the same system. For this reason, port 2812 is Monit's default port.
 
 TIP: Make sure the Firewall settings allow traffic on port 2812.
 

--- a/src/ollama/front-ends.adoc
+++ b/src/ollama/front-ends.adoc
@@ -45,7 +45,7 @@ You can also pass in the name of any model listed in `ollama ls`:
 ollama launch claude --model gemma4:31b
 ----
 
-If you want to make Ollama the default provider, and to set default models, add the following to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.). The auth token can be any value – Ollama ignores it's value.
+If you want to make Ollama the default provider, and to set default models, add the following to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.). The auth token can be any value – Ollama ignores its value.
 
 [source,sh]
 ----


### PR DESCRIPTION
Changes to `src/ollama/front-ends.adoc`:
- "Ollama ignores it's value" → "Ollama ignores its value"