### PR TITLE
proof: tmux

### DIFF
--- a/src/monit/README.adoc
+++ b/src/monit/README.adoc
@@ -36,7 +36,7 @@ The "with start delay" line prevents Monit from running a test immediately after
 
 == Web interface
 
-Monit comes with its own built-in web server, for displaying the system tests as a web page. Monit's server needs to run on a different port than other web servers running on the same system. FOr this reason, port 2812 is Monit's default port.
+Monit comes with its own built-in web server, for displaying the system tests as a web page. Monit's server needs to run on a different port than other web servers running on the same system. For this reason, port 2812 is Monit's default port.
 
 TIP: Make sure the Firewall settings allow traffic on port 2812.
 

--- a/src/ollama/front-ends.adoc
+++ b/src/ollama/front-ends.adoc
@@ -45,7 +45,7 @@ You can also pass in the name of any model listed in `ollama ls`:
 ollama launch claude --model gemma4:31b
 ----
 
-If you want to make Ollama the default provider, and to set default models, add the following to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.). The auth token can be any value – Ollama ignores it's value.
+If you want to make Ollama the default provider, and to set default models, add the following to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.). The auth token can be any value – Ollama ignores its value.
 
 [source,sh]
 ----

--- a/src/spring-framework/application-configuration.adoc
+++ b/src/spring-framework/application-configuration.adoc
@@ -1,6 +1,6 @@
 = Spring: Application configuration
 
-Spring Boot simplifies many fo the necessary configurations required to build a Spring application. Configuration files are named `application.properties` or `application.yml` and they allow developers to set properties that control behaviors of the application, such as:
+Spring Boot simplifies many of the necessary configurations required to build a Spring application. Configuration files are named `application.properties` or `application.yml` and they allow developers to set properties that control behaviors of the application, such as:
 
 * *Server configuration*: The default port, session settings, and other server parameters.
 

--- a/src/tmux/README.adoc
+++ b/src/tmux/README.adoc
@@ -94,7 +94,7 @@ To detach from a session, type `Ctrl+b d`. This closes tmux but keeps the sessio
 
 Detaching from a session does not close it. Your tmux session, with all its windows and panes, will continue to run in the background. To list all sessions, type `tmux list-sessions` or `tmux ls`.
 
-The easiest was to kill whole running sessions is to use `tmux kill-session -t <session-name>` from outside a tmux session. From inside a tmux session, you can kill the current session – closing all its windows and panes – by pressing the prefix `Ctrl-b` then typing `:kill-session` and press `Enter`. Alternatively, just `exit` from each pane individually until there are non left.
+The easiest way to kill whole running sessions is to use `tmux kill-session -t <session-name>` from outside a tmux session. From inside a tmux session, you can kill the current session – closing all its windows and panes – by pressing the prefix `Ctrl-b` then typing `:kill-session` and press `Enter`. Alternatively, just `exit` from each pane individually until there are none left.
 
 === Pane controls
 


### PR DESCRIPTION
Changes to `src/tmux/README.adoc`:
- "The easiest was to kill" → "The easiest way to kill"
- "non left" → "none left"