### PR TITLE
proof: react

### DIFF
--- a/src/react/forms.adoc
+++ b/src/react/forms.adoc
@@ -5,7 +5,7 @@
 This documentation is up-to-date with React v17. React v18 introduced a new hook called `useActionState` that makes it much easier to work with forms in React.
 ======
 
-Working with native forms forms is one React's weak points.
+Working with native forms is one React's weak points.
 
 Traditionally, to dynamically send form data to a server, you would listen to a form's `submit` event, prevent the default action, capture the values of all the form's inputs, and send the data to an HTTP endpoint. In React, it is better practice to dynamically track the state of form inputs, syncing the values of the inputs with the state of the React components that wrap them – literally on every keystroke as the user enters data.
 
@@ -248,7 +248,7 @@ export default function Form() {
       <br />
       <br />
 
-      <!-- When a button is in a form, it's default is `type="submit"`. -->
+      <!-- When a button is in a form, its default is `type="submit"`. -->
       <button>Submit</button>
     </form>
   )

--- a/src/react/hooks/effects.adoc
+++ b/src/react/hooks/effects.adoc
@@ -21,7 +21,7 @@ export default function App() {
 }
 ----
 
-Why does this happen? The component renders initially with no data. Then, when the `fetch` is resolved, the component state is updated, triggering a re-render of the component. But because the `fetch` code is at the top level of the component, it is executed again. This is how React works - when a component is re-rendered, literally it's top-level logic is re-run.
+Why does this happen? The component renders initially with no data. Then, when the `fetch` is resolved, the component state is updated, triggering a re-render of the component. But because the `fetch` code is at the top level of the component, it is executed again. This is how React works - when a component is re-rendered, literally its top-level logic is re-run.
 
 So you have to be careful about what you do in the top-level of a component.
 

--- a/src/react/hooks/state.adoc
+++ b/src/react/hooks/state.adoc
@@ -399,7 +399,7 @@ export default function App() {
     elements have changed, been added, or been removed when multiple instances
     of the same component type exist. But it is not available as a prop inside
     the components themselves – `props.key` is always undefined. Best practice
-    is to use use a prop named `id` where you need child components to
+    is to use a prop named `id` where you need child components to
     have a reference to their unique key.
     */
     <Box


### PR DESCRIPTION
Changes to `src/react/forms.adoc`:
- "native forms forms" → "native forms"
- "it's default is`type="submit"`" → "its default is`type="submit"`"